### PR TITLE
Update super-serial to be able to import sound

### DIFF
--- a/super-serial/package.json
+++ b/super-serial/package.json
@@ -24,6 +24,7 @@
     "@babel/preset-react": "^7.16.0",
     "babel-loader": "^8.2.3",
     "concurrently": "^8.2.2",
+    "expose-loader": "^4.1.0",
     "html-webpack-plugin": "^5.5.0",
     "webpack": "^5.64.1",
     "webpack-cli": "^4.9.1",

--- a/super-serial/webpack.config.js
+++ b/super-serial/webpack.config.js
@@ -14,6 +14,15 @@ module.exports = {
         exclude: /node_modules/,
         use: "babel-loader",
       },
+      {
+        test: require.resolve("p5"),
+        use: [
+          {
+            loader: "expose-loader",
+            options: { exposes: ["p5"] },
+          },
+        ],
+      },
     ],
   },
   plugins: [


### PR DESCRIPTION
Added the requirements to package.json and webpack.config.js to the super-serial app that enable importing the p5 sound library into sketch.js